### PR TITLE
🔒️ build(deps): bump go version to 1.24.4 (#312)

### DIFF
--- a/networking/mqtt/Dockerfile
+++ b/networking/mqtt/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.2 AS build
+FROM golang:1.24.4 AS build
 
 WORKDIR /build
 

--- a/networking/mqtt/go.mod
+++ b/networking/mqtt/go.mod
@@ -1,6 +1,6 @@
 module mqtt-workout
 
-go 1.24.2
+go 1.24.4
 
 require github.com/eclipse/paho.mqtt.golang v1.5.0
 


### PR DESCRIPTION
```console
➜  mqtt git:(312-bump-go-version-to-1244-on-mqtt-example) ✗ grype mqtt-app
 ✔ Loaded image                                                  mqtt-app:latest
 ✔ Parsed image                    sha256:60919ff2a5fb51a0f2509d1d9f51f922c7f4981   ✔ Cataloged contents              02b56e0657784af0e6d85bea7cfbe6a4cf5a223b2a6be8     ├── ✔ Packages                        [6 packages]
   ├── ✔ File digests                    [1 files]
   ├── ✔ Executables                     [1 executables]
   └── ✔ File metadata                   [1 locations]
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]                          ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored
No vulnerabilities found
```