### PR TITLE
🔧 build(golangci-lint): update to version v2.8.0 (#373)

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,4 +24,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.6.1
+          version: v2.8.0


### PR DESCRIPTION
Updated the golangci-lint action version from v2.6.1 to v2.8.0 in the GitHub Actions workflow for improved linting performance and features.