### PR TITLE
🔧 fix(logging): address goconst warnings in logrus example (#400)

### DIFF
--- a/logging/logrus/main.go
+++ b/logging/logrus/main.go
@@ -6,27 +6,30 @@ import (
 
 func main() {
 	log.SetLevel(log.InfoLevel)
+	event := "event"
+	duration := "duration"
+	place := "place"
 	proteinLogger := log.WithFields(log.Fields{
-		"event":    "Drink Protein Shake",
-		"duration": "2 min",
-		"place":    "Room",
+		event:    "Drink Protein Shake",
+		duration: "2 min",
+		place:    "Room",
 	})
 
 	warmupLogger := log.WithFields(log.Fields{
-		"event":    "Warm-Up",
-		"duration": "10 min",
-		"place":    "Playground",
+		event:    "Warm-Up",
+		duration: "10 min",
+		place:    "Playground",
 	})
 
 	HIITLogger := log.WithFields(log.Fields{
-		"event":    "HIIT Workout",
-		"duration": "40 min",
-		"place":    "Workout place",
+		event:    "HIIT Workout",
+		duration: "40 min",
+		place:    "Workout place",
 	})
 	MarathonLogger := log.WithFields(log.Fields{
-		"event":    "Run a marathon",
-		"duration": "3 hours",
-		"place":    "Riverside",
+		event:    "Run a marathon",
+		duration: "3 hours",
+		place:    "Riverside",
 	})
 
 	proteinLogger.Info("morning")


### PR DESCRIPTION
Define reusable log field keys and replace repeated string literals in WithFields maps to satisfy golangci-lint goconst checks and reduce duplication.

Signed-off-by: Mao-Kai Lan <45162039+mukappalambda@users.noreply.github.com>
