### PR TITLE
✨ feat(logging/slog): add error logging example using slog (#404)

### DIFF
--- a/logging/slog/error-logging/main.go
+++ b/logging/slog/error-logging/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+)
+
+var ErrInvalidAmount = errors.New("amount less than zero")
+
+func main() {
+	ctx := context.Background()
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	_ = ProcessPayment(ctx, logger, 10)
+	_ = ProcessPayment(ctx, logger, -5)
+}
+
+func ProcessPayment(ctx context.Context, logger *slog.Logger, amount int) error {
+	if amount < 0 {
+		logger.With("main", "process-payment").ErrorContext(ctx, "payment failed", "amount", amount, "err", ErrInvalidAmount)
+		return ErrInvalidAmount
+	}
+
+	logger.With("main", "process-payment").InfoContext(ctx, "payment succeeded", "amount", amount)
+	return nil
+}


### PR DESCRIPTION
Add a runnable slog JSON logging sample demonstrating ErrorContext and InfoContext for payment processing, including structured fields and a negative-amount error case.

Signed-off-by: Mao-Kai Lan <45162039+mukappalambda@users.noreply.github.com>
