### PR TITLE
📝 feat(logging/slog): add request-scoped logging example (#408)

### DIFF
--- a/logging/slog/request-scoped-logging/main.go
+++ b/logging/slog/request-scoped-logging/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+)
+
+const (
+	KeyRequestID = "request_id"
+	KeyUserID    = "user_id"
+)
+
+func main() {
+	initialLogger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	requestID := "my-request-id"
+	userID := 123
+	logger := WithRequestLogger(initialLogger, requestID, userID)
+	HandleRequest(context.Background(), logger)
+}
+
+func WithRequestLogger(logger *slog.Logger, requestID string, userID int) *slog.Logger {
+	return logger.With(KeyRequestID, requestID, KeyUserID, userID)
+}
+
+func HandleRequest(ctx context.Context, logger *slog.Logger) {
+	logger.InfoContext(ctx, "request started")
+	logger.InfoContext(ctx, "request finished")
+}


### PR DESCRIPTION
Introduce a new Go example demonstrating request-scoped slog usage, attaching request_id and user_id fields to a logger and emitting start/finish logs via InfoContext.

Signed-off-by: Mao-Kai Lan <45162039+mukappalambda@users.noreply.github.com>
